### PR TITLE
Add MaterialPalette Reference

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -36,21 +36,27 @@ config.ini {
 	//	Please choose one option below and delete the 2 forward slashes " // " at the start of that line.
 	//	When you are done, make sure every OTHER line in this section is commented out.
 
-			include "resource/colors/sky.styles"
-			//include "resource/colors/sea.styles"
-			//include "resource/colors/breeze.styles"
-			//include "resource/colors/slate.styles"
-			//include "resource/colors/truffle.styles"
-			//include "resource/colors/gunmetal.styles"
-			//include "resource/colors/silver.styles"
-			//include "resource/colors/grass.styles"
-			//include "resource/colors/rose.styles"
-			//include "resource/colors/cinnabar.styles"
-			//include "resource/colors/lavender.styles"
-			//include "resource/colors/lilac.styles"
-			//include "resource/colors/deeppurple.styles"
-			//include "resource/colors/steamblue.styles"
-			//include "resource/colors/youtubered.styles"
+	// The second set of "//" in any line should be left.
+	// These are notes to compare to MaterialPalette.com's color selection
+	// Colors noted with "-ish" are really close, but not quite the ones
+	// on Material Palette.
+	// Colors noted with "// NMP" aren't on Material Palette at all
+
+			include "resource/colors/sky.styles"		// Blue
+			//include "resource/colors/sea.styles"		// Teal
+			//include "resource/colors/breeze.styles"	// Light Blue
+			//include "resource/colors/slate.styles"	// Blue Grey
+			//include "resource/colors/truffle.styles"	// Dark Brown	// NMP
+			//include "resource/colors/gunmetal.styles"	// Black	// NMP
+			//include "resource/colors/silver.styles"	// Grey-ish
+			//include "resource/colors/grass.styles"	// Green
+			//include "resource/colors/rose.styles"		// Pink-ish
+			//include "resource/colors/cinnabar.styles"	// Red-ish
+			//include "resource/colors/lavender.styles"	// Indigo-ish
+			//include "resource/colors/lilac.styles"	// Deep Purple-ish
+			//include "resource/colors/deeppurple.styles" 	// Deep Purple
+			//include "resource/colors/steamblue.styles" 	// Steam Blue	// NMP
+			//include "resource/colors/youtubered.styles" 	// YouTube Red	// NMP
 
 			//User contributed themes
 			//include "resource/colors/user/numix.styles" //Contributed by Markus-Deviant (markus-deviant.deviantart.com), Numix Project by Satyajit (satya164.deviantart.com)


### PR DESCRIPTION
The Google Photos album doesn't seem to have the images named, and this is a very helpful reference when choosing a theme.