### PR TITLE
Fix control in Web Browser Settings

### DIFF
--- a/Resource/layout/subpaneloptionsbrowser.layout
+++ b/Resource/layout/subpaneloptionsbrowser.layout
@@ -7,8 +7,9 @@
 		place { control=DescriptionLabel width=max }
 		place { control=OverlayHomePageLabel start=DescriptionLabel dir=down y=30 }
 		place { control=OverlayHomePage start=OverlayHomePageLabel width=max dir=down y=5 }
+		place { controls=ClientBrowserAuthHomePage start=OverlayHomePage width=max dir=down y=15 }
 
-		place { control=ClearWebCacheButton,ClearAllCookiesButton start=OverlayHomePage dir=down y=30 }
+		place { control=ClearWebCacheButton,ClearAllCookiesButton start=ClientBrowserAuthHomePage dir=down y=20 }
 
 		place { control=Divider1 height=0 width=0 }
 	}


### PR DESCRIPTION
Added control "ClientBrowserAuthHomePage" to fix overlapping control in "Web Browser" category in Settings.

Before:
![image](https://cloud.githubusercontent.com/assets/11904616/26288832/3985bb92-3e4e-11e7-8204-c8767309bed7.png)

After:
![image](https://cloud.githubusercontent.com/assets/11904616/26288847/81aba1ac-3e4e-11e7-9c14-4bb0f2aefa60.png)

