### PR TITLE
Added Controller Settings Layout

### DIFF
--- a/Resource/layout/subpaneloptionscontroller.layout
+++ b/Resource/layout/subpaneloptionscontroller.layout
@@ -1,0 +1,19 @@
+"resource/layout/subpaneloptionscontroller.layout"
+{
+
+	styles {
+	}
+
+	layout {
+		place { control=TitleLabel margin-right=20 width=max }
+		place { control=DescriptionLabel start=TitleLabel dir=down width=max margin-top=15 }
+		place { control=GeneralSettingsButton start=DescriptionLabel dir=down height=20 width=260 margin-top=15 }
+
+		place { control=Divider1 start=GeneralSettingsButton dir=down width=max margin-top=15 }
+
+		place { control=DescriptionBindingLabel start=Divider1 height=40 width=max dir=down margin-top=8 }
+		place { control=BigPictureConfigButton start=DescriptionBindingLabel dir=down height=20 width=260 }
+		place { control=DesktopConfigButton start=BigPictureConfigButton dir=down height=20 width=260 }
+		place { control=GuideConfigButton start=DesktopConfigButton dir=down height=20 width=260 }
+	}
+}


### PR DESCRIPTION
- Squashed everything together, and fixed the button text cutoff

I'm pretty sure this is the only way to fix the text being cut off in one of the buttons as in my issue #155. I also got rid of all that extra space and squashed things together to try and match with the rest of the theme.

![steam_2017-06-02_13-17-11](https://cloud.githubusercontent.com/assets/10183015/26709522/8c6fa556-4796-11e7-894e-8809d0b7aeb9.png)
